### PR TITLE
feat: qube tab count

### DIFF
--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -15,19 +15,35 @@ class AppDatabase extends _$AppDatabase {
 
   Stream<List<QubeItem>> allIQubeItems() => select(qubeItems).watch();
 
+  Stream<int> qubeItemsCount() => qubeItems.count().watchSingle();
+
   Future<void> insertMockData() async {
     final allQubeItems = await select(qubeItems).get();
 
     if (allQubeItems.isNotEmpty) return;
 
-    into(qubeItems).insert(
-      QubeItemsCompanion.insert(
-        date: 'May 2, 2024',
-        identification: '#1230ASD120',
-        location: 'Greenbelt tower 1',
-        receiver: 'Mr. Klean 1',
-        time: '7:00 PM',
-      ),
+    batch(
+      (batch) {
+        batch.insertAll(
+          qubeItems,
+          [
+            QubeItemsCompanion.insert(
+              date: 'May 2, 2024',
+              identification: '#1230ASD120',
+              location: 'Greenbelt tower 1',
+              receiver: 'Mr. Klean 1',
+              time: '7:00 PM',
+            ),
+            QubeItemsCompanion.insert(
+              date: 'May 2, 2024',
+              identification: '#1230ASD121',
+              location: 'Greenbelt tower 1',
+              receiver: 'Mr. Klean 1',
+              time: '7:30 PM',
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/qube_list/qube_list_page.dart
+++ b/lib/qube_list/qube_list_page.dart
@@ -5,7 +5,6 @@ import 'package:qube_project/qube_list/widgets/qube_card.dart';
 import 'package:qube_project/qube_list/widgets/qube_list_tab.dart';
 import 'package:qube_project/utils/const.dart';
 import 'package:qube_project/utils/strings.dart';
-import 'package:qube_project/utils/styles.dart';
 import 'package:qube_project/widgets/spacings.dart';
 
 class QubeListPage extends StatefulWidget {
@@ -57,17 +56,27 @@ class _QubeListPageState extends State<QubeListPage> with SingleTickerProviderSt
               tabs: [
                 ListenableBuilder(
                   listenable: _tabController,
-                  builder: (_, __) => QubeListTab(
-                    label: step1Label,
-                    countColor: Colors.black.withOpacity(tabIndex == 0 ? 1 : unselectedTabOpacity),
+                  builder: (_, __) => StreamBuilder<int>(
+                    stream: appDatabase.qubeItemsCount(),
+                    builder: (_, snapshot) => QubeListTab(
+                      label: step1Label,
+                      countColor: Colors.black.withOpacity(tabIndex == 0 ? 1 : unselectedTabOpacity),
+                      count: snapshot.data ?? 0,
+                    ),
                   ),
                 ),
                 ListenableBuilder(
                   listenable: _tabController,
-                  builder: (_, __) => Opacity(
-                    opacity: tabIndex == 1 ? 1 : unselectedTabOpacity,
-                    child: const QubeListTab(label: step2Label),
-                  ),
+                  builder: (_, __) {
+                    final isSelected = tabIndex == 1;
+                    return Opacity(
+                      opacity: isSelected ? 1 : unselectedTabOpacity,
+                      child: QubeListTab(
+                        label: step2Label,
+                        count: isSelected ? 1 : 0,
+                      ),
+                    );
+                  },
                 ),
               ],
             ),
@@ -82,9 +91,10 @@ class _QubeListPageState extends State<QubeListPage> with SingleTickerProviderSt
                   stream: appDatabase.allIQubeItems(),
                   builder: (_, snapshot) {
                     final allQubeItems = [...?snapshot.data];
-                    return ListView.builder(
+                    return ListView.separated(
                       itemCount: allQubeItems.length,
                       itemBuilder: (_, index) => QubeCard(qubeItem: allQubeItems[index]),
+                      separatorBuilder: (_, __) => const VerticalSpace(space: 20.0),
                     );
                   },
                 ),

--- a/lib/qube_list/widgets/qube_list_tab.dart
+++ b/lib/qube_list/widgets/qube_list_tab.dart
@@ -6,12 +6,14 @@ import 'package:qube_project/widgets/spacings.dart';
 class QubeListTab extends StatelessWidget {
   const QubeListTab({
     required this.label,
+    required this.count,
     this.countColor = Colors.black,
     super.key,
   });
 
   final String label;
   final Color countColor;
+  final int count;
 
   @override
   Widget build(BuildContext context) {
@@ -33,8 +35,7 @@ class QubeListTab extends StatelessWidget {
               color: Colors.white,
             ),
             child: Text(
-              // TODO: Update value
-              '0',
+              count.toString(),
               style: TextStyles.semiBold.copyWith(
                 color: countColor,
                 fontSize: 13.5,


### PR DESCRIPTION
- add qube items count method in database
- add multipe mock ddata
- add count parameter in qube list tab
- use list view seperated for qube cards
- wrap step 1 tab with stream builder for qube items count in qube list page