### PR TITLE
feat: qube card interaction

### DIFF
--- a/lib/qube_list/widgets/qube_card.dart
+++ b/lib/qube_list/widgets/qube_card.dart
@@ -8,9 +8,11 @@ import 'package:qube_project/widgets/spacings.dart';
 class QubeCard extends StatelessWidget {
   const QubeCard({
     required this.qubeItem,
+    required this.onPress,
     super.key,
   });
 
+  final VoidCallback onPress;
   final QubeItem qubeItem;
 
   @override
@@ -58,8 +60,7 @@ class QubeCard extends StatelessWidget {
           ),
           const VerticalSpace(space: 20.0),
           ElevatedButton(
-            // TODO: Add function
-            onPressed: () {},
+            onPressed: onPress,
             style: ElevatedButton.styleFrom(
               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(qubeCardButtonRadius)),
               backgroundColor: buttonColor,


### PR DESCRIPTION
- add on press parameter in qube card
- remove unnecessary tab index notifier
- dellete unnecessary on update tab function
- wrap whole tab bar wih listenable builder
- remove value listenable builders
- use absorb painter for tab in qube list page toi avoid clicking on step 2
- add on navigate to step 2 function