### PR TITLE
feat: tab bar shimmer

### DIFF
--- a/lib/home/home.dart
+++ b/lib/home/home.dart
@@ -27,7 +27,7 @@ class Home extends StatelessWidget {
                 const VerticalSpace(space: 32.0),
                 HomeAppBar(isGettingList: isGettingList),
                 const VerticalSpace(space: 20.0),
-                const SearchField(),
+                SearchField(isGettingList: isGettingList),
                 const VerticalSpace(space: 12.0),
                 const QubeListConnector(),
               ],

--- a/lib/home/widgets/search_field.dart
+++ b/lib/home/widgets/search_field.dart
@@ -4,27 +4,37 @@ import 'package:qube_project/utils/strings.dart';
 import 'package:qube_project/utils/styles.dart';
 
 class SearchField extends StatelessWidget {
-  const SearchField({super.key});
+  const SearchField({
+    required this.isGettingList,
+    super.key,
+  });
+
+  final bool isGettingList;
 
   @override
   Widget build(BuildContext context) {
     final border = OutlineInputBorder(borderRadius: BorderRadius.circular(searchBarRadius));
-    return SizedBox(
-      height: searchBarHeight,
-      child: TextField(
-        decoration: InputDecoration(
-          prefixIcon: const Icon(
-            Icons.search,
-            size: searchIconSize,
-            color: Colors.white,
+    return AnimatedOpacity(
+      duration: kThemeChangeDuration,
+      opacity: isGettingList ? disabledSearchOpacity : 1,
+      child: SizedBox(
+        height: searchBarHeight,
+        child: TextField(
+          decoration: InputDecoration(
+            prefixIcon: const Icon(
+              Icons.search,
+              size: searchIconSize,
+              color: Colors.white,
+            ),
+            enabled: !isGettingList,
+            contentPadding: EdgeInsets.zero,
+            alignLabelWithHint: false,
+            floatingLabelBehavior: FloatingLabelBehavior.never,
+            hintText: searchBarHintText,
+            hintStyle: TextStyles.xxs,
+            border: border.copyWith(borderSide: const BorderSide(color: Colors.white10)),
+            focusedBorder: border.copyWith(borderSide: const BorderSide(color: Colors.white)),
           ),
-          contentPadding: EdgeInsets.zero,
-          alignLabelWithHint: false,
-          floatingLabelBehavior: FloatingLabelBehavior.never,
-          hintText: searchBarHintText,
-          hintStyle: TextStyles.xxs,
-          border: border.copyWith(borderSide: const BorderSide(color: Colors.white10)),
-          focusedBorder: border.copyWith(borderSide: const BorderSide(color: Colors.white)),
         ),
       ),
     );

--- a/lib/qube_list/qube_list_connector.dart
+++ b/lib/qube_list/qube_list_connector.dart
@@ -14,6 +14,7 @@ class QubeListConnector extends StatelessWidget {
       builder: (_, vm) => QubeListPage(
         onSelectQube: vm.onSelectQube,
         isPosting: vm.isPosting,
+        isGettingList: vm.isGettingList,
       ),
     );
   }

--- a/lib/qube_list/qube_list_page.dart
+++ b/lib/qube_list/qube_list_page.dart
@@ -10,11 +10,13 @@ class QubeListPage extends StatefulWidget {
   const QubeListPage({
     required this.onSelectQube,
     required this.isPosting,
+    required this.isGettingList,
     super.key,
   });
 
   final ValueChanged<QubeItem> onSelectQube;
   final bool isPosting;
+  final bool isGettingList;
 
   @override
   State<QubeListPage> createState() => _QubeListPageState();
@@ -50,6 +52,7 @@ class _QubeListPageState extends State<QubeListPage> with SingleTickerProviderSt
           QubeListTab(
             tabController: _tabController,
             isPosting: widget.isPosting,
+            isGettingList: widget.isGettingList,
           ),
           const VerticalSpace(space: 32.0),
           Expanded(

--- a/lib/qube_list/qube_list_vm.dart
+++ b/lib/qube_list/qube_list_vm.dart
@@ -10,6 +10,7 @@ class QubeListVmFactory extends VmFactory<AppState, QubeListConnector, QubeListV
   QubeListVM fromStore() => QubeListVM(
         onSelectQube: _onSelectQube,
         isPosting: state.wait.isWaiting(DeliverAction.waitKey),
+        isGettingList: state.wait.isWaiting(GetInitialListAction.waitKey),
       );
 
   void _onSelectQube(QubeItem selectedQube) => dispatch(SelectQubeAction(selectedQube: selectedQube));
@@ -18,9 +19,16 @@ class QubeListVmFactory extends VmFactory<AppState, QubeListConnector, QubeListV
 class QubeListVM extends Vm {
   final ValueChanged<QubeItem> onSelectQube;
   final bool isPosting;
+  final bool isGettingList;
 
   QubeListVM({
     required this.onSelectQube,
     required this.isPosting,
-  }) : super(equals: [isPosting]);
+    required this.isGettingList,
+  }) : super(
+          equals: [
+            isPosting,
+            isGettingList,
+          ],
+        );
 }

--- a/lib/qube_list/widgets/qube_list_tab.dart
+++ b/lib/qube_list/widgets/qube_list_tab.dart
@@ -3,15 +3,18 @@ import 'package:qube_project/main.dart';
 import 'package:qube_project/qube_list/step_2/widgets/step_tab_button.dart';
 import 'package:qube_project/utils/const.dart';
 import 'package:qube_project/utils/strings.dart';
+import 'package:qube_project/widgets/loading_shimmer.dart';
 
 class QubeListTab extends StatelessWidget {
   const QubeListTab({
     required this.tabController,
+    required this.isGettingList,
     required this.isPosting,
     super.key,
   });
 
   final TabController tabController;
+  final bool isGettingList;
   final bool isPosting;
 
   /// Navigate back to Step 1 when pressing back while on Step 2
@@ -27,7 +30,7 @@ class QubeListTab extends StatelessWidget {
         height: tabBarHeight,
         padding: tabBarPadding,
         decoration: BoxDecoration(
-          color: buttonColor,
+          color: isGettingList ? qubeListTabShimmerColor : buttonColor,
           borderRadius: borderRadius,
         ),
         child: ListenableBuilder(
@@ -45,27 +48,29 @@ class QubeListTab extends StatelessWidget {
                   dividerColor: Colors.transparent,
                   indicator: BoxDecoration(
                     borderRadius: borderRadius,
-                    gradient: qubeGradient,
+                    gradient: isGettingList ? null : qubeGradient,
                   ),
                   indicatorSize: TabBarIndicatorSize.tab,
-                  tabs: [
-                    StreamBuilder<int>(
-                      stream: appDatabase.qubeItemsCount(),
-                      builder: (_, snapshot) => StepTabButton(
-                        label: step1Label,
-                        countColor: Colors.black.withOpacity(isStep1 ? 1 : unselectedTabOpacity),
-                        count: snapshot.data ?? 0,
-                      ),
-                    ),
-                    AnimatedOpacity(
-                      duration: kThemeAnimationDuration,
-                      opacity: !isStep1 ? 1 : unselectedTabOpacity,
-                      child: StepTabButton(
-                        label: step2Label,
-                        count: !isStep1 ? 1 : 0,
-                      ),
-                    ),
-                  ],
+                  tabs: isGettingList
+                      ? List.generate(2, (_) => const LoadingShimmer(width: 100))
+                      : [
+                          StreamBuilder<int>(
+                            stream: appDatabase.qubeItemsCount(),
+                            builder: (_, snapshot) => StepTabButton(
+                              label: step1Label,
+                              countColor: Colors.black.withOpacity(isStep1 ? 1 : unselectedTabOpacity),
+                              count: snapshot.data ?? 0,
+                            ),
+                          ),
+                          AnimatedOpacity(
+                            duration: kThemeAnimationDuration,
+                            opacity: !isStep1 ? 1 : unselectedTabOpacity,
+                            child: StepTabButton(
+                              label: step2Label,
+                              count: !isStep1 ? 1 : 0,
+                            ),
+                          ),
+                        ],
                 ),
               ),
             );

--- a/lib/utils/const.dart
+++ b/lib/utils/const.dart
@@ -26,6 +26,7 @@ const homeAppBarPadding = EdgeInsets.symmetric(horizontal: 8.0);
 const searchBarHeight = 38.0;
 const searchBarRadius = 1000.0;
 const searchIconSize = 18.0;
+const disabledSearchOpacity = 0.4;
 
 // Qube List Page
 const tabBarRadius = 100.0;
@@ -36,6 +37,7 @@ const qubeCountRadius = 12.0;
 const unselectedTabOpacity = 0.7;
 const dateIndicatorPadding = EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0);
 const qubeListTabLoadingOpacity = 0.3;
+const qubeListTabShimmerColor = Color(0xff171718);
 
 // Qube Card
 const qubeCardPadding = EdgeInsets.all(20.0);


### PR DESCRIPTION
- add is getting list property in search field, qube list page, vm, and tab
- wrap search field with animated opacity and disable if getting list
- use loading shimmer in qube list tab if getting list
- add consts