### PR TITLE
chore: followed by

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,10 +25,9 @@ void main() async {
         actionObservers: [if (kDebugMode) ConsoleActionObserver<AppState>()],
       ),
       child: DevicePreview(
-        tools: [
-          ...DevicePreview.defaultTools,
+        tools: DevicePreview.defaultTools.followedBy([
           DevicePreviewScreenshot(onScreenshot: screenshotAsFiles(Directory(downloadDirectory))),
-        ],
+        ]).toList(),
         builder: (_) => const HomeConnector(),
       ),
     ),


### PR DESCRIPTION
- use followed by instead of spread operator when setting device preview tools in main