### PR TITLE
chore: dart 3.9.2

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,6 +11,9 @@ analyzer:
   errors:
     invalid_annotation_target: ignore
 
+formatter:
+  trailing_commas: preserve
+
 linter:
   rules:
     always_declare_return_types: true

--- a/lib/feature/qube_list/qube_list_vm.dart
+++ b/lib/feature/qube_list/qube_list_vm.dart
@@ -29,9 +29,9 @@ class QubeListVM extends Vm {
     required this.isPosting,
     required this.isGettingList,
   }) : super(
-          equals: [
-            isPosting,
-            isGettingList,
-          ],
-        );
+         equals: [
+           isPosting,
+           isGettingList,
+         ],
+       );
 }

--- a/lib/feature/qube_list/step_2/step_2_tab.dart
+++ b/lib/feature/qube_list/step_2/step_2_tab.dart
@@ -34,19 +34,17 @@ class Step2Tab extends StatefulWidget {
 }
 
 class _Step2TabState extends State<Step2Tab> {
-  late final GlobalKey<FormState> _formKey;
+  late final _formKey = GlobalKey<FormState>();
   late final _nameTextController = TextEditingController();
   late final _emailTextController = TextEditingController();
   late final _phoneTextController = TextEditingController();
-  late String _emailHintText;
+  late String _emailHintText = _emailHintText;
 
   @override
   void initState() {
-    _formKey = GlobalKey<FormState>();
     _nameTextController.addListener(() => widget.onUpdateForm(QubeDetailsForm.name(_nameTextController.text)));
     _emailTextController.addListener(() => widget.onUpdateForm(QubeDetailsForm.email(_emailTextController.text)));
     _phoneTextController.addListener(() => widget.onUpdateForm(QubeDetailsForm.phone(_phoneTextController.text)));
-    _emailHintText = emailHintText;
     super.initState();
   }
 
@@ -81,10 +79,11 @@ class _Step2TabState extends State<Step2Tab> {
   @override
   Widget build(BuildContext context) {
     final deliveryDate = widget.selectedQube?.deliveryDate ?? DateTime.now();
-    final qubeDetails = widget.qubeDetails;
     final isDeliverSuccessful = widget.isSuccessful == true;
     final areDetailsFilled =
-        qubeDetails.name.isNotEmpty && qubeDetails.email.isNotEmpty && qubeDetails.phone.isNotEmpty;
+        widget.qubeDetails.name.isNotEmpty &&
+        widget.qubeDetails.email.isNotEmpty &&
+        widget.qubeDetails.phone.isNotEmpty;
     final isTextFieldEnabled = !widget.isLoading && !isDeliverSuccessful;
     const largeVerticalSpace = VerticalSpace(space: 16.0);
     const mediumVerticalSpace = VerticalSpace(space: 12.0);
@@ -145,14 +144,14 @@ class _Step2TabState extends State<Step2Tab> {
                   label: isDeliverSuccessful
                       ? postedLabel
                       : widget.isLoading
-                          ? postingLabel
-                          : deliverButtonLabel,
+                      ? postingLabel
+                      : deliverButtonLabel,
                   onPress: widget.isLoading || !areDetailsFilled ? null : _onPressDeliver,
                 ),
               ),
             ],
           ),
-        )
+        ),
       ],
     );
   }

--- a/lib/feature/qube_list/step_2/step_2_tab_vm.dart
+++ b/lib/feature/qube_list/step_2/step_2_tab_vm.dart
@@ -10,13 +10,13 @@ import 'package:qube_project/state/app_state.dart';
 class Step2TabVmFactory extends VmFactory<AppState, Step2TabConnector, Step2TabVM> {
   @override
   Step2TabVM fromStore() => Step2TabVM(
-        isLoading: state.wait.isWaiting(DeliverAction.waitKey),
-        onDeliver: _onDeliver,
-        isSuccessful: state.isSuccessful,
-        selectedQube: state.selectedQube,
-        onUpdateForm: _onUpdateForm,
-        qubeDetails: _qubeDetails,
-      );
+    isLoading: state.wait.isWaiting(DeliverAction.waitKey),
+    onDeliver: _onDeliver,
+    isSuccessful: state.isSuccessful,
+    selectedQube: state.selectedQube,
+    onUpdateForm: _onUpdateForm,
+    qubeDetails: _qubeDetails,
+  );
 
   QubeDetails get _qubeDetails => state.qubeDetails ?? const QubeDetails();
 
@@ -49,11 +49,11 @@ class Step2TabVM extends Vm {
     required this.isSuccessful,
     required this.onUpdateForm,
   }) : super(
-          equals: [
-            selectedQube,
-            qubeDetails,
-            isLoading,
-            isSuccessful,
-          ],
-        );
+         equals: [
+           selectedQube,
+           qubeDetails,
+           isLoading,
+           isSuccessful,
+         ],
+       );
 }

--- a/lib/feature/qube_list/step_2/widgets/details_field.dart
+++ b/lib/feature/qube_list/step_2/widgets/details_field.dart
@@ -57,14 +57,15 @@ class _DetailsFieldState extends State<DetailsField> {
           disabledBorder: border,
           prefixIcon: ValueListenableBuilder<bool>(
             valueListenable: _isErrorNotifier,
-            builder: (_, isError, __) => Container(
+            builder: (_, isError, _) => Container(
               margin: detailsCardPrefixMargin,
-              foregroundDecoration: isError
-                  ? const BoxDecoration(
-                      color: errorFieldColor,
-                      shape: BoxShape.circle,
-                    )
-                  : null,
+              foregroundDecoration: switch (isError) {
+                true => const BoxDecoration(
+                  color: errorFieldColor,
+                  shape: BoxShape.circle,
+                ),
+                false => null,
+              },
               child: const GradientPoint(),
             ),
           ),

--- a/lib/feature/qube_list/widgets/loading_list.dart
+++ b/lib/feature/qube_list/widgets/loading_list.dart
@@ -42,7 +42,7 @@ class LoadingList extends StatelessWidget {
             physics: const NeverScrollableScrollPhysics(),
             itemCount: 3,
             shrinkWrap: true,
-            separatorBuilder: (_, __) => const VerticalSpace(space: 20.0),
+            separatorBuilder: (_, _) => const VerticalSpace(space: 20.0),
             itemBuilder: (_, itemIndex) {
               const verticalSpace = VerticalSpace(space: 4.0);
               return Container(

--- a/lib/feature/qube_list/widgets/qube_list.dart
+++ b/lib/feature/qube_list/widgets/qube_list.dart
@@ -26,7 +26,7 @@ class QubeList extends StatelessWidget {
 
         return ListView.separated(
           itemCount: groupedQubeItems.length,
-          separatorBuilder: (_, __) => const VerticalSpace(space: 32.0),
+          separatorBuilder: (_, _) => const VerticalSpace(space: 32.0),
           itemBuilder: (_, groupIndex) {
             final qubeItemEntry = groupedQubeItems[groupIndex];
             final qubeItems = qubeItemEntry.second;
@@ -39,7 +39,7 @@ class QubeList extends StatelessWidget {
                   physics: const NeverScrollableScrollPhysics(),
                   itemCount: qubeItems.length,
                   shrinkWrap: true,
-                  separatorBuilder: (_, __) => const VerticalSpace(space: 20.0),
+                  separatorBuilder: (_, _) => const VerticalSpace(space: 20.0),
                   itemBuilder: (_, itemIndex) {
                     final qubeItem = qubeItems[itemIndex];
                     return QubeCard(

--- a/lib/feature/qube_list/widgets/qube_list_tab.dart
+++ b/lib/feature/qube_list/widgets/qube_list_tab.dart
@@ -35,13 +35,13 @@ class QubeListTab extends StatelessWidget {
         ),
         child: ListenableBuilder(
           listenable: tabController,
-          builder: (_, __) {
+          builder: (_, _) {
             final isStep1 = tabController.index == 0;
             return AbsorbPointer(
               absorbing: isPosting || isStep1,
               child: PopScope(
                 canPop: isStep1,
-                onPopInvokedWithResult: (_, __) => _onPopInvoked(),
+                onPopInvokedWithResult: (_, _) => _onPopInvoked(),
                 child: TabBar(
                   splashBorderRadius: borderRadius,
                   controller: tabController,
@@ -51,26 +51,27 @@ class QubeListTab extends StatelessWidget {
                     gradient: isGettingList ? null : qubeGradient,
                   ),
                   indicatorSize: TabBarIndicatorSize.tab,
-                  tabs: isGettingList
-                      ? List.generate(2, (_) => const LoadingShimmer(width: 100))
-                      : [
-                          StreamBuilder<int>(
-                            stream: appDatabase.qubeItemsCount(),
-                            builder: (_, snapshot) => StepTabButton(
-                              label: step1Label,
-                              countColor: Colors.black.withValues(alpha: isStep1 ? 1 : unselectedTabOpacity),
-                              count: snapshot.data ?? 0,
-                            ),
-                          ),
-                          AnimatedOpacity(
-                            duration: kThemeAnimationDuration,
-                            opacity: !isStep1 ? 1 : unselectedTabOpacity,
-                            child: StepTabButton(
-                              label: step2Label,
-                              count: !isStep1 ? 1 : 0,
-                            ),
-                          ),
-                        ],
+                  tabs: switch (isGettingList) {
+                    true => List.generate(2, (_) => const LoadingShimmer(width: 100)),
+                    false => [
+                      StreamBuilder<int>(
+                        stream: appDatabase.qubeItemsCount(),
+                        builder: (_, snapshot) => StepTabButton(
+                          label: step1Label,
+                          countColor: Colors.black.withValues(alpha: isStep1 ? 1 : unselectedTabOpacity),
+                          count: snapshot.data ?? 0,
+                        ),
+                      ),
+                      AnimatedOpacity(
+                        duration: kThemeAnimationDuration,
+                        opacity: !isStep1 ? 1 : unselectedTabOpacity,
+                        child: StepTabButton(
+                          label: step2Label,
+                          count: !isStep1 ? 1 : 0,
+                        ),
+                      ),
+                    ],
+                  },
                 ),
               ),
             );

--- a/lib/state/action/actions.dart
+++ b/lib/state/action/actions.dart
@@ -41,10 +41,10 @@ class DeliverAction extends LoadingAction {
 class ResetDetailsAction extends ReduxAction<AppState> {
   @override
   AppState reduce() => state.copyWith(
-        isSuccessful: null,
-        selectedQube: null,
-        qubeDetails: null,
-      );
+    isSuccessful: null,
+    selectedQube: null,
+    qubeDetails: null,
+  );
 }
 
 /// Selects a qube to be shown in Step 2

--- a/lib/utils/styles.dart
+++ b/lib/utils/styles.dart
@@ -18,9 +18,9 @@ class TextStyles {
   static TextStyle get semiBold => poppinsStyles.copyWith(fontWeight: FontWeight.w600);
 
   static TextStyle get xxs => regular.copyWith(
-        fontSize: 12.0,
-        color: Colors.white.withValues(alpha: 0.5),
-      );
+    fontSize: 12.0,
+    color: Colors.white.withValues(alpha: 0.5),
+  );
 
   static TextStyle get base => medium.copyWith(fontSize: 16.0);
 }

--- a/lib/widgets/gradient_point.dart
+++ b/lib/widgets/gradient_point.dart
@@ -14,16 +14,17 @@ class GradientPoint extends StatelessWidget {
     return ShaderMask(
       blendMode: BlendMode.srcIn,
       shaderCallback: (bounds) => qubeGradient.createShader(Rect.fromLTWH(0, 0, bounds.width, bounds.height)),
-      child: isFilled
-          ? const CircleAvatar(radius: gradientPointSize / 2)
-          : Container(
-              height: gradientPointSize,
-              width: gradientPointSize,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                border: Border.all(),
-              ),
-            ),
+      child: switch (isFilled) {
+        true => const CircleAvatar(radius: gradientPointSize / 2),
+        false => Container(
+          height: gradientPointSize,
+          width: gradientPointSize,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(),
+          ),
+        ),
+      },
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1059,5 +1059,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.2 <4.0.0"
   flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: ^3.5.3
+  sdk: ^3.9.2
 
 drift_version: &drift_version 2.28.1
 


### PR DESCRIPTION
- set dart sdk to 3.9.2 in pubspec
- preserve formatter trailing commas in analysis options
- use switch instead of ternaries under builds
- format
- remove unnecessary underscores
- directly initialize form key and email hint text in step 2 tab